### PR TITLE
Updates to tooling and VS code settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
         python-version: [ 3.9 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: 1.0.10
+        poetry-version: 1.1.14
 
     - name: Install dependencies
       run: poetry install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-docstrings]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.931"
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.formatOnSave": true,
+    },
+    "editor.rulers": [88],
+
+    // Enable relevant linters
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+
+    // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
+    "python.testing.pytestArgs": ["--no-cov"],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ isort = "^5.10.1"
 pre-commit = "^2.18.1"
 black = "^22.3.0"
 
+[tool.mypy]
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ pytest-mock = "^3.7.0"
 isort = "^5.10.1"
 pre-commit = "^2.18.1"
 black = "^22.3.0"
+flake8 = "^4.0.1"
+flake8-docstrings = "^1.6.0"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,13 +15,6 @@ max-line-length = 88
 extend-ignore =
 	E203,
 
-[mypy]
-ignore_missing_imports = True
-strict_optional = False
-
-[mypy-setup]
-ignore_errors = True
-
 [isort]
 line_length = 88
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,13 @@ max-line-length = 88
 max-line-length = 88
 extend-ignore =
 	E203,
+required-plugins =
+	flake8-docstring,
+docstring-convention = google
+
+# Disable all the warnings pertaining to missing docstrings. Remove this line if
+# you want to enforce the use of docstrings for public methods etc.
+ignore = D1
 
 [isort]
 line_length = 88


### PR DESCRIPTION
Conceptually, this could be split into several different PRs as you might not want all these changes, but I thought seeing as it was a fairly small diff it'd be easier to review in one go (plus most of this stuff has been reviewed for iPANACEA anyway). If there are any parts you don't want I can just drop the relevant commits.

Commit summary:
- Use default values for more mypy settings. There's a longer justification in the commit log (https://github.com/ImperialCollegeLondon/poetry_template_2/commit/6bc7ff35cfc07147a8872b09f876fdde03f2e2ad), but essentially I think the defaults are more sensible. I haven't mandated use of types everywhere, so this is just about ensuring the correctness of specified types. We could do that though!
- Bump versions of GitHub actions
- Some sensible default VS code settings (enabling linters etc.)