### PR TITLE
Mandate docstrings for all public modules, methods etc.

### DIFF
--- a/myproject/__init__.py
+++ b/myproject/__init__.py
@@ -1,1 +1,2 @@
+"""The main module for MyProject."""
 __version__ = "0.1.0"

--- a/myproject/__main__.py
+++ b/myproject/__main__.py
@@ -1,0 +1,1 @@
+"""The entry point for the myproject program."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test = pytest
 
 [tool:pytest]
 addopts =
-	-v --flake8 --mypy -p no:logging
+	-v --flake8 --mypy -p no:warnings
 	--cov=myproject  --cov-report=html:htmlcov/coverage
 	--doctest-modules --ignore=myproject/__main__.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test = pytest
 
 [tool:pytest]
 addopts =
-	-v --flake8 --mypy -p no:warnings
+	-v --flake8 --mypy -p no:logging
 	--cov=myproject  --cov-report=html:htmlcov/coverage
 	--doctest-modules --ignore=myproject/__main__.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,10 @@ max-line-length = 88
 max-line-length = 88
 extend-ignore =
 	E203,
+	# D1,  # Uncomment to disable enforcing docstrings 
 required-plugins =
 	flake8-docstring,
 docstring-convention = google
-
-# Disable all the warnings pertaining to missing docstrings. Remove this line if
-# you want to enforce the use of docstrings for public methods etc.
-ignore = D1
 
 [isort]
 line_length = 88

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,6 @@
 """Unit tests for MyProject."""
+
+from logging import getLogger
+
+# Disable flake8 logger as it can be rather verbose
+getLogger("flake8").propagate = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for MyProject."""

--- a/tests/test_myproject.py
+++ b/tests/test_myproject.py
@@ -1,5 +1,7 @@
+"""Tests for the main module."""
 from myproject import __version__
 
 
 def test_version():
+    """Check that the version is acceptable."""
     assert __version__ == "0.1.0"


### PR DESCRIPTION
Hi both,

I thought this might merit discussion and I thought the easiest way to do that was just to open a PR.

After just having gone through the pain of going through the iPANACEA code base and adding docstrings everywhere, I'm wondering whether for new projects we should just mandate them? Obviously people can opt out by changing the settings back again, but I feel like it's probably sensible to require docstrings from the get-go. It isn't like the whole mypy thing, where people may or may not want to enforce types; regardless of what kind of project we're doing, I think it makes sense to have docstrings.

What do you think?