### PR TITLE
pyproject.toml: Change authors field to the correct format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 name = "MyProject"
 version = "0.1.0"
 description = ""
-authors = ["Jane Doe <jane_doe@some_email.com>"]
+authors = [
+    { name = "Jane Doe", email = "jane_doe@some_email.com" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
[Discussion elsewhere](https://github.com/ImperialCollegeLondon/Solidity-GUI/pull/8#issuecomment-1295212065) has brought to light that we have been doing this wrong in our projects.

It mostly shouldn't be a problem, but it is incorrect and in the linked project a bad value for ``authors`` was triggering some weird error condition in ``pip-tools``.

I guess we should fix it up elsewhere, too!