### PR TITLE
Use Node.js version of markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,9 @@ repos:
     rev: "v0.982"
     hooks:
       - id: mypy
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: "v0.12.0"
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.32.2
     hooks:
       - id: markdownlint
-        args: ["-r", "~MD013"]
+        args: ["--disable", "MD013"]
+        


### PR DESCRIPTION
The Ruby version is troublesome for local development because Ruby needs to be available and the version needs to keep up with the version required by markdownlint. The Node.js version doesn't appear to have this issue.