### PR TITLE
Fix: flake8 has moved to GitHub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: "22.10.0"
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
The upstream URL for flake8 has changed. It will still carry on working if you already have your pre-commit hooks installed, but if you try installing them now, it'll break.

Update the URL.