### PR TITLE
CI: Use latest version of `poetry` for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2.1.6
       with:
-        poetry-version: 1.1.14
+        poetry-version: 1.2.2
 
     - name: Install dependencies
       run: poetry install


### PR DESCRIPTION
Seemingly poetry v1.2 introduces some breaking changes, so it'd be best if we were using the most up to date version on our CI system to check that everything works.