### PR TITLE
Fix pre-commit hook for markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,5 +26,4 @@ repos:
     rev: v0.35.0
     hooks:
       - id: markdownlint
-        args: ["--disable", "MD013"]
-        
+        args: ["--disable", "MD013", "--"]


### PR DESCRIPTION
Unfortunately it seems that this hook has been broken since it was introduced. The problem is that when disabling rules you need an extra "--" at the end of the list. See: https://github.com/igorshubovych/markdownlint-cli

Frustratingly, passing malformed arguments to markdownlint-cli means that the hook always passes (!). Upstream issue: https://github.com/igorshubovych/markdownlint-cli/issues/409

I re-ran the hook on this repo, though, and there were no issues with the markdown.

Tagging everyone as a PSA :smile: 