### PR TITLE
Remove deprecated VS Code settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,8 @@
 {
     "recommendations": [
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.mypy-type-checker",
         "ms-python.python"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,9 @@
 {
-    "python.formatting.provider": "black",
     "[python]": {
         "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "editor.rulers": [88],
-
-    // Enable relevant linters
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
 
     // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
     "python.testing.pytestArgs": ["--no-cov"],


### PR DESCRIPTION
This PR removes deprecated VS Code options related to Python and adds the various linter extensions etc. to the list of recommended extensions.

A similar approach is needed for the Essential Software Engineering course's code.