### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Description
+
+*Please include a summary of the change and which issue is fixed (if any). Please also
+include relevant motivation and context. List any dependencies that are required for
+this change.*
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] Documentation (non-breaking change that adds or improves the documentation)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Optimization (non-breaking, back-end change that speeds up the code)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Breaking change (whatever its nature)
+
+## Key checklist
+
+- [ ] All tests pass (eg. `python -m pytest`)
+- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
+- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
+
+## Further checks
+
+- [ ] Code is commented, particularly in hard-to-understand areas
+- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))


### PR DESCRIPTION
I went to copy the pull request template from this repo over to FINESSE and discovered it didn't have one. Let's remedy that.

I've copied over the one from the pip-tools-template repo.