### PR TITLE
Tweaks to tooling

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,26 +1,3 @@
 ---
 # Disable checks here
 MD013: false
-
-# Disable checks that conflict with Prettier
-blanks-around-fences: false
-blanks-around-headings: false
-blanks-around-lists: false
-code-fence-style: false
-emphasis-style: false
-heading-start-left: false
-hr-style: false
-list-indent: false
-list-marker-space: false
-no-blanks-blockquote: false
-no-hard-tabs: false
-no-missing-space-atx: false
-no-missing-space-closed-atx: false
-no-multiple-blanks: false
-no-multiple-space-atx: false
-no-multiple-space-blockquote: false
-no-multiple-space-closed-atx: false
-no-trailing-spaces: false
-ol-prefix: false
-strong-style: false
-ul-indent: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,9 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        # Prettier supports many other file formats (e.g., JavaScript, HTML; see
+        # https://prettier.io for list). Add other types here.
+        types_or: [yaml, json]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
         # Prettier supports many other file formats (e.g., JavaScript, HTML; see
         # https://prettier.io for list). Add other types here.
         types_or: [yaml, json]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
-    hooks:
-      - id: pyupgrade
-        args: ["--py311-plus"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.3.0"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,18 @@ addopts = "-v --mypy -p no:warnings --cov=myproject --cov-report=html --doctest-
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.ruff]
+target-version = "py311"
+
 [tool.ruff.lint]
-select = ["D", "E", "F", "I"] # pydocstyle, pycodestyle, Pyflakes, isort
+select = [
+    "D",   # pydocstyle
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+]
+pydocstyle.convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D100", "D104"] # Missing docstring in public module, Missing docstring in public package
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ select = [
     "F",   # Pyflakes
     "I",   # isort
     "UP",  # pyupgrade
+    "RUF"  # ruff
 ]
 pydocstyle.convention = "google"
 


### PR DESCRIPTION
# Description

After using this template, I noticed that the `prettier` `pre-commit` hook will happily run over *all* committed files, including formats it doesn't support, e.g. `.py` files. While it's essentially harmless, it does introduce a noticeable time delay in running the hook sometimes. So I've restricted it to just format JSON and YAML files for now.

I also noticed that we're still using a separate hook for `pyupgrade`, even though `ruff` has most of these checks too. So I enabled the `pyupgrade` checks for `ruff` and removed the `pyupgrade` hook. I also enabled `ruff`'s own checks while I was at it (I've used them for FINESSE and they also seem useful).

I've only requested @dalonsoa and @AdrianDAlessandro as reviewers because you guys normally review these PRs and I didn't want to spam the whole team... anyone else is welcome to jump in though!