### PR TITLE
VS Code: We no longer need to pass `--no-cov` to `pytest`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,6 @@
     },
     "editor.rulers": [88],
 
-    // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
-    "python.testing.pytestArgs": ["--no-cov"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
It seems the upstream issue that required this workaround has been resolved, so we can drop it.

More annoyingly, I've found that we've copied this file around between other projects and if `pytest-cov` isn't installed, it means that passing the `--no-cov` argument will just break it so you can't run your tests from VS Code. At least now, hopefully we won't copy it around anymore!
